### PR TITLE
Fix private log_time() method invocation

### DIFF
--- a/lib/redmine_undev_git/includes/repo_fetch.rb
+++ b/lib/redmine_undev_git/includes/repo_fetch.rb
@@ -247,7 +247,7 @@ module RedmineUndevGit::Includes::RepoFetch
       # log time for issues
       if Setting.commit_logtime_enabled?
         parsed[:log_time].each do |issue, hours|
-          changeset.log_time(issue, hours)
+          changeset.log_time_wrapped(issue, hours)
         end
       end
     end

--- a/lib/redmine_undev_git/patches/changeset_patch.rb
+++ b/lib/redmine_undev_git/patches/changeset_patch.rb
@@ -86,6 +86,9 @@ module RedmineUndevGit
         tag
       end
 
+      def log_time_wrapped(issue, hours)
+        log_time(issue, hours)
+      end
     end
   end
 end

--- a/lib/redmine_undev_git/patches/changeset_patch.rb
+++ b/lib/redmine_undev_git/patches/changeset_patch.rb
@@ -87,7 +87,13 @@ module RedmineUndevGit
       end
 
       def log_time_wrapped(issue, hours)
-        log_time(issue, hours)
+        if hours.kind_of?(Array)
+          hours.each do |h|
+            log_time(issue, h)
+          end
+        else
+          log_time(issue, hours)
+        end
       end
     end
   end


### PR DESCRIPTION
`Changeset::log_time()` method has been made private in Redmine, thus its direct invocation is not allowed anymore. This PR adds a wrapping method to circumvent this problem. Also this method resolves argument type error: `hours` argument is of type `Array` while `log_time()` method assumes it is either `string` or `float`. 